### PR TITLE
Make stderr redirection compatible with Fish 3.0.

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -55,21 +55,21 @@ function fish_prompt --description 'Write out the prompt'
     function __fish_repaint_user --on-variable fish_color_user --description "Event handler, repaint when fish_color_user changes"
       if status --is-interactive
         set -e __fish_prompt_user
-        commandline -f repaint ^/dev/null
+        commandline -f repaint 2> /dev/null
       end
     end
 
     function __fish_repaint_host --on-variable fish_color_host --description "Event handler, repaint when fish_color_host changes"
       if status --is-interactive
         set -e __fish_prompt_host
-        commandline -f repaint ^/dev/null
+        commandline -f repaint 2> /dev/null
       end
     end
 
     function __fish_repaint_status --on-variable fish_color_status --description "Event handler; repaint when fish_color_status changes"
       if status --is-interactive
         set -e __fish_prompt_status
-        commandline -f repaint ^/dev/null
+        commandline -f repaint 2> /dev/null
       end
     end
   end


### PR DESCRIPTION
Fish has deprecated `^` as a shortcut for stderr redirection in 3.0. Replace it with the more
compatible `2>`.

See oh-my-fish/oh-my-fish#609 and oh-my-fish/oh-my-fish#618